### PR TITLE
Replace hard-coded id with id of current user

### DIFF
--- a/src/App.elm
+++ b/src/App.elm
@@ -77,7 +77,7 @@ update msg model =
                                 |> Task.perform FetchConversations FetchConversations
                             )
 
-                        _ ->
+                        LoggedOut ->
                             ( model, Cmd.none )
 
                 Err error ->
@@ -90,21 +90,14 @@ update msg model =
             in
                 let
                     authStatus =
-                        case info of
-                            Just loginInfo ->
-                                LoggedIn loginInfo
-
-                            Nothing ->
-                                LoggedOut
+                        info
+                            |> Maybe.map LoggedIn
+                            |> Maybe.withDefault LoggedOut
 
                     fetchMyUser =
-                        case info of
-                            Just loginInfo ->
-                                fetchMe loginInfo
-                                    |> Task.perform FetchMeFailed FetchMeLoaded
-
-                            Nothing ->
-                                Cmd.none
+                        info
+                            |> Maybe.map (fetchMe >> Task.perform FetchMeFailed FetchMeLoaded)
+                            |> Maybe.withDefault Cmd.none
                 in
                     ( { model
                         | loggedOut = loggedOut

--- a/src/App.elm
+++ b/src/App.elm
@@ -66,22 +66,22 @@ update msg model =
             ( model, Cmd.none )
 
         FetchMeLoaded result ->
-            case result of
-                Ok me ->
-                    case model.authStatus of
-                        LoggedIn loginInfo ->
-                            ( { model
-                                | loggedIn = LIUpdate.setMe model.loggedIn me
-                              }
-                            , fetchConversations loginInfo me.id
-                                |> Task.perform FetchConversations FetchConversations
-                            )
+            result
+                |> Result.map
+                    (\me ->
+                        case model.authStatus of
+                            LoggedIn loginInfo ->
+                                ( { model
+                                    | loggedIn = LIUpdate.setMe model.loggedIn me
+                                  }
+                                , fetchConversations loginInfo me.id
+                                    |> Task.perform FetchConversations FetchConversations
+                                )
 
-                        LoggedOut ->
-                            ( model, Cmd.none )
-
-                Err error ->
-                    ( model, Cmd.none )
+                            LoggedOut ->
+                                ( model, Cmd.none )
+                    )
+                |> Result.withDefault ( model, Cmd.none )
 
         LoggedOutMsg subMsg ->
             let

--- a/src/Tasks/FetchConversations.elm
+++ b/src/Tasks/FetchConversations.elm
@@ -15,15 +15,15 @@ type alias ConversationTask =
     Task (Result String ( Dict Int Conversation, Dict Int User )) (Result String ( Dict Int Conversation, Dict Int User ))
 
 
-fetchConversations : LoginInfo -> ConversationTask
-fetchConversations loginInfo =
+fetchConversations : LoginInfo -> Int -> ConversationTask
+fetchConversations loginInfo myUserId =
     { verb = "GET"
     , headers =
         [ ( "Authorization", "Basic:api:" ++ loginInfo.apiKey )
         , ( "Content-Type", "application/json;charset=UTF-8" )
         , ( "Accept", "application/json" )
         ]
-    , url = Http.url "https://app.communityshare.us/api/conversation" [ ( "user_id", "976" ) ]
+    , url = Http.url "https://app.communityshare.us/api/conversation" [ ( "user_id", toString myUserId ) ]
     , body = Http.empty
     }
         |> Http.send Http.defaultSettings


### PR DESCRIPTION
Previously, the user ID in `FetchConversations.elm` was hard coded as `976`. This means that other CS users cannot develop on this app because their API calls will be rejected.

@dmsnell Feel free to comment on anything, as usual. In particular, does adding one more `Int` arg to `fetchConversations` make sense, or is there a different level of abstraction/type that makes more sense?
#### Testing

There should be no functional changes if you were user `976`. Logging in as a user other than the user with `id == 976` should work just like `976` now.
